### PR TITLE
グローバルなコマンド引数をパースするように修正

### DIFF
--- a/scripts/nifcloud-debugcli
+++ b/scripts/nifcloud-debugcli
@@ -6,6 +6,7 @@ import awscli.help
 from awscli import (EnvironmentVariables, argparser, clidocs, clidriver,
                     handlers, topictags)
 from awscli.argprocess import ParamShorthandParser, uri_param
+from awscli.customizations.globalargs import register_parse_global_args
 from awscli.plugin import HierarchicalEmitter, load_plugins
 from botocore import __version__ as botocore_version
 
@@ -187,6 +188,7 @@ def awscli_initialize(event_handlers):
     event_handlers.register('load-cli-arg', uri_param)
     param_shorthand = ParamShorthandParser()
     event_handlers.register('process-cli-arg', param_shorthand)
+    register_parse_global_args(event_handlers)
 
 
 handlers.awscli_initialize = awscli_initialize


### PR DESCRIPTION
## 概要

* `nifcloud-debugcli` でグローバルなコマンド引数がパースされるように修正しました
    * 参考:
        * [aws\-cli/handlers\.py at 888b4f68accce9578ec2367d2d700912c74c3916 · aws/aws\-cli](https://github.com/aws/aws-cli/blob/888b4f68accce9578ec2367d2d700912c74c3916/awscli/handlers.py#L56)
        * [aws\-cli/globalargs\.py at 888b4f68accce9578ec2367d2d700912c74c3916 · aws/aws\-cli](https://github.com/aws/aws-cli/blob/888b4f68accce9578ec2367d2d700912c74c3916/awscli/customizations/globalargs.py#L24)
* これによって下記のコマンド引数が正常に動作するようになるはず
    * `--query` (この p-r で動くようになった)
    * `--endpoint-url` (これはもともと動いていたっぽい)
    * `--ca-bundle` (この p-r で動くようになった)
    * `--no-sign` (この p-r で動くようになった)
    * `--cli-connect-timeout` (動作確認できなかったのでいったん保留で)
    * `--cli-read-timeout` (動作確認できなかったのでいったん保留で)

## テスト

* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli computing describe-instances --query "ReservationSet[*].InstancesSet[*].[InstanceId,InstanceState.Name,IpAddress,PrivateIpAddress,InstanceType]" --output table`
    * 下記のような出力が得られること

```
------------------------------------------------------------------------
|                           DescribeInstances                          |
+-------------+----------+----------------+----------------+-----------+
|  hogehoge   |  running |  XXX.XXX.XX.XX |  YY.YYY.YY.YY  |  mini     |
|  hogehoge2  |  stopped |                |                |  mini     |
|  hogehoge4  |  stopped |                |                |  mini     |
+-------------+----------+----------------+----------------+-----------+
```

* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli computing describe-instances --no-sign`
    * `An error occurred (Client.AuthFailureRequired.AccessKey) when calling the DescribeInstances operation: No access key was provided.` というエラーが発生すること
* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli computing describe-instances --ca-bundle hoge`
    * `[Errno 2] No such file or directory` というエラーが発生すること