### PR TITLE
Add `register_add_waiters` handler to support wait command of nifcloud-debugcli

### DIFF
--- a/scripts/nifcloud-debugcli
+++ b/scripts/nifcloud-debugcli
@@ -7,6 +7,7 @@ from awscli import (EnvironmentVariables, argparser, clidocs, clidriver,
                     handlers, topictags)
 from awscli.argprocess import ParamShorthandParser, uri_param
 from awscli.customizations.globalargs import register_parse_global_args
+from awscli.customizations.waiters import register_add_waiters
 from awscli.plugin import HierarchicalEmitter, load_plugins
 from botocore import __version__ as botocore_version
 
@@ -189,6 +190,7 @@ def awscli_initialize(event_handlers):
     param_shorthand = ParamShorthandParser()
     event_handlers.register('process-cli-arg', param_shorthand)
     register_parse_global_args(event_handlers)
+    register_add_waiters(event_handlers)
 
 
 handlers.awscli_initialize = awscli_initialize


### PR DESCRIPTION
# 概要
- `nifcloud-debugcli` で wait コマンドを使えるようにしました。

# 確認事項
- `PYTHONPATH=. python scripts/nifcloud-debugcli computing run-instances --image-id 89 --instance-type e-mini --key-name ${some_key_name} --instance-id clitest001` でインスタンスを作成する。
- [x] ` PYTHONPATH=. python ./scripts/nifcloud-debugcli computing wait instance-running --instance-id clitest001` でインスタンス作成完了まで wait できること。
- [x] 上記コマンド終了後、 `PYTHONPATH=. python scripts/nifcloud-debugcli computing describe-instances --instance-id clitest001 --output table --query "ReservationSet[].InstancesSet[].InstanceState"` で `Name` が `running` になっていること。