### PR TITLE
Fixed version of the following dependencies: botocore and awscli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
                                'data/topics/*',
                                'data/*/*/*.json']},
     include_package_data=True,
-    install_requires=['botocore>=1.9.11', 'awscli>=1.14.63'],
+    install_requires=['botocore==1.9.16', 'awscli==1.14.63'],
     license='Apache License 2.0',
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
# Summary
- `setup.py` に定義してある依存ライブラリのバージョンを固定しました。
- botocore のバージョンを awscli 1.14.63 の `setup.py` で指定 (固定) されている 1.9.16 に変更しました。
    - これによって、 pip install 時の warning がでなくなります。

# Tests
- [ ] Docker コンテナ内で新規に nifcloud-debugcli を install し、動作すること。

```
# docker run -it --rm -v $(pwd):/work -w /work python:3.6.5 bash
# pip install .
# nifcloud-debugcli --version
```