### PR TITLE
fix #11, and add location names for other SDKs

### DIFF
--- a/nifcloud/data/nas/N2016-02-24/service-2.json
+++ b/nifcloud/data/nas/N2016-02-24/service-2.json
@@ -182,7 +182,7 @@
     "AuthorizeNASSecurityGroupIngressResult": {
       "members": {
         "NASSecurityGroup": {
-          "shape": "NASSecurityGroupResult"
+          "shape": "NASSecurityGroup"
         }
       },
       "name": "AuthorizeNASSecurityGroupIngressResult",
@@ -245,7 +245,7 @@
     "CreateNASInstanceResult": {
       "members": {
         "NASInstance": {
-          "shape": "NASInstanceResult"
+          "shape": "NASInstance"
         }
       },
       "name": "CreateNASInstanceResult",
@@ -272,17 +272,18 @@
     "CreateNASSecurityGroupResult": {
       "members": {
         "NASSecurityGroup": {
-          "shape": "NASSecurityGroupResult"
+          "shape": "NASSecurityGroup"
         }
       },
       "name": "CreateNASSecurityGroupResult",
       "type": "structure"
     },
-    "DatapointsResult": {
+    "Datapoints": {
       "member": {
-        "shape": "MemberResult"
+        "locationName": "member",
+        "shape": "Member"
       },
-      "name": "DatapointsResult",
+      "name": "Datapoints",
       "type": "list"
     },
     "DeleteNASInstanceRequest": {
@@ -306,7 +307,7 @@
     "DeleteNASInstanceResult": {
       "members": {
         "NASInstance": {
-          "shape": "NASInstanceResult"
+          "shape": "NASInstance"
         }
       },
       "name": "DeleteNASInstanceResult",
@@ -335,7 +336,7 @@
     "DescribeNASInstancesResult": {
       "members": {
         "NASInstances": {
-          "shape": "NASInstancesResult"
+          "shape": "NASInstances"
         }
       },
       "name": "DescribeNASInstancesResult",
@@ -354,13 +355,13 @@
     "DescribeNASSecurityGroupsResult": {
       "members": {
         "NASSecurityGroups": {
-          "shape": "NASSecurityGroupsResult"
+          "shape": "NASSecurityGroups"
         }
       },
       "name": "DescribeNASSecurityGroupsResult",
       "type": "structure"
     },
-    "DomainControllerResult": {
+    "DomainController": {
       "members": {
         "Hostname": {
           "shape": "String"
@@ -369,21 +370,22 @@
           "shape": "String"
         }
       },
-      "name": "DomainControllerResult",
+      "name": "DomainController",
       "type": "structure"
     },
-    "DomainControllersResult": {
+    "DomainControllers": {
       "member": {
-        "shape": "DomainControllerResult"
+        "locationName": "DomainController",
+        "shape": "DomainController"
       },
-      "name": "DomainControllersResult",
+      "name": "DomainControllers",
       "type": "list"
     },
     "Double": {
       "name": "Double",
       "type": "double"
     },
-    "EndpointResult": {
+    "Endpoint": {
       "members": {
         "Address": {
           "shape": "String"
@@ -392,7 +394,7 @@
           "shape": "String"
         }
       },
-      "name": "EndpointResult",
+      "name": "Endpoint",
       "type": "structure"
     },
     "GetMetricStatisticsRequest": {
@@ -420,7 +422,7 @@
     "GetMetricStatisticsResult": {
       "members": {
         "Datapoints": {
-          "shape": "DatapointsResult"
+          "shape": "Datapoints"
         },
         "Label": {
           "shape": "String"
@@ -429,7 +431,7 @@
       "name": "GetMetricStatisticsResult",
       "type": "structure"
     },
-    "IPRangeResult": {
+    "IPRange": {
       "members": {
         "CIDRIP": {
           "shape": "String"
@@ -438,21 +440,22 @@
           "shape": "String"
         }
       },
-      "name": "IPRangeResult",
+      "name": "IPRange",
       "type": "structure"
     },
-    "IPRangesResult": {
+    "IPRanges": {
       "member": {
-        "shape": "IPRangeResult"
+        "locationName": "IPRange",
+        "shape": "IPRange"
       },
-      "name": "IPRangesResult",
+      "name": "IPRanges",
       "type": "list"
     },
     "Integer": {
       "name": "Integer",
       "type": "integer"
     },
-    "MemberResult": {
+    "Member": {
       "members": {
         "SampleCount": {
           "shape": "String"
@@ -467,7 +470,7 @@
           "shape": "String"
         }
       },
-      "name": "MemberResult",
+      "name": "Member",
       "type": "structure"
     },
     "ModifyNASInstanceRequest": {
@@ -531,7 +534,7 @@
     "ModifyNASInstanceResult": {
       "members": {
         "NASInstance": {
-          "shape": "NASInstanceResult"
+          "shape": "NASInstance"
         }
       },
       "name": "ModifyNASInstanceResult",
@@ -558,25 +561,13 @@
     "ModifyNASSecurityGroupResult": {
       "members": {
         "NASSecurityGroup": {
-          "shape": "NASSecurityGroupResult"
+          "shape": "NASSecurityGroup"
         }
       },
       "name": "ModifyNASSecurityGroupResult",
       "type": "structure"
     },
-    "NASInstanceErrorInfoResult": {
-      "members": {
-        "NASInstanceErrorCode": {
-          "shape": "String"
-        },
-        "NASInstanceErrorMessage": {
-          "shape": "String"
-        }
-      },
-      "name": "NASInstanceErrorInfoResult",
-      "type": "structure"
-    },
-    "NASInstanceResult": {
+    "NASInstance": {
       "members": {
         "AllocatedStorage": {
           "shape": "String"
@@ -594,10 +585,10 @@
           "shape": "String"
         },
         "DomainControllers": {
-          "shape": "DomainControllersResult"
+          "shape": "DomainControllers"
         },
         "Endpoint": {
-          "shape": "EndpointResult"
+          "shape": "Endpoint"
         },
         "MasterUsername": {
           "shape": "String"
@@ -609,7 +600,7 @@
           "shape": "String"
         },
         "NASInstanceErrorInfo": {
-          "shape": "NASInstanceErrorInfoResult"
+          "shape": "NASInstanceErrorInfo"
         },
         "NASInstanceIdentifier": {
           "shape": "String"
@@ -621,7 +612,7 @@
           "shape": "Integer"
         },
         "NASSecurityGroups": {
-          "shape": "NASSecurityGroupsResult"
+          "shape": "NASSecurityGroups"
         },
         "NetworkId": {
           "shape": "String"
@@ -636,23 +627,36 @@
           "shape": "Integer"
         }
       },
-      "name": "NASInstanceResult",
+      "name": "NASInstance",
       "type": "structure"
     },
-    "NASInstancesResult": {
-      "member": {
-        "shape": "NASInstanceResult"
+    "NASInstanceErrorInfo": {
+      "members": {
+        "NASInstanceErrorCode": {
+          "shape": "String"
+        },
+        "NASInstanceErrorMessage": {
+          "shape": "String"
+        }
       },
-      "name": "NASInstancesResult",
+      "name": "NASInstanceErrorInfo",
+      "type": "structure"
+    },
+    "NASInstances": {
+      "member": {
+        "locationName": "NASInstance",
+        "shape": "NASInstance"
+      },
+      "name": "NASInstances",
       "type": "list"
     },
-    "NASSecurityGroupResult": {
+    "NASSecurityGroup": {
       "members": {
         "AvailabilityZone": {
           "shape": "String"
         },
         "IPRanges": {
-          "shape": "IPRangesResult"
+          "shape": "IPRanges"
         },
         "NASSecurityGroupDescription": {
           "shape": "String"
@@ -664,17 +668,18 @@
           "shape": "String"
         },
         "SecurityGroups": {
-          "shape": "SecurityGroupsResult"
+          "shape": "SecurityGroups"
         }
       },
-      "name": "NASSecurityGroupResult",
+      "name": "NASSecurityGroup",
       "type": "structure"
     },
-    "NASSecurityGroupsResult": {
+    "NASSecurityGroups": {
       "member": {
-        "shape": "NASSecurityGroupResult"
+        "locationName": "NASSecurityGroup",
+        "shape": "NASSecurityGroup"
       },
-      "name": "NASSecurityGroupsResult",
+      "name": "NASSecurityGroups",
       "type": "list"
     },
     "RequestDimensions": {
@@ -750,13 +755,13 @@
     "RevokeNASSecurityGroupIngressResult": {
       "members": {
         "NASSecurityGroup": {
-          "shape": "NASSecurityGroupResult"
+          "shape": "NASSecurityGroup"
         }
       },
       "name": "RevokeNASSecurityGroupIngressResult",
       "type": "structure"
     },
-    "SecurityGroupResult": {
+    "SecurityGroup": {
       "members": {
         "SecurityGroupName": {
           "shape": "String"
@@ -768,14 +773,15 @@
           "shape": "String"
         }
       },
-      "name": "SecurityGroupResult",
+      "name": "SecurityGroup",
       "type": "structure"
     },
-    "SecurityGroupsResult": {
+    "SecurityGroups": {
       "member": {
-        "shape": "SecurityGroupResult"
+        "locationName": "SecurityGroup",
+        "shape": "SecurityGroup"
       },
-      "name": "SecurityGroupsResult",
+      "name": "SecurityGroups",
       "type": "list"
     },
     "String": {

--- a/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
+++ b/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
@@ -602,6 +602,7 @@
     },
     "AvailabilityZones": {
       "member": {
+        "locationName": "AvailabilityZone",
         "shape": "AvailabilityZone"
       },
       "name": "AvailabilityZones",
@@ -931,6 +932,7 @@
     },
     "DBEngineVersions": {
       "member": {
+        "locationName": "DBEngineVersion",
         "shape": "DBEngineVersion"
       },
       "name": "DBEngineVersions",
@@ -1061,6 +1063,7 @@
     },
     "DBInstances": {
       "member": {
+        "locationName": "DBInstance",
         "shape": "DBInstance"
       },
       "name": "DBInstances",
@@ -1083,6 +1086,7 @@
     },
     "DBParameterGroups": {
       "member": {
+        "locationName": "DBParameterGroup",
         "shape": "DBParameterGroup"
       },
       "name": "DBParameterGroups",
@@ -1114,6 +1118,7 @@
     },
     "DBSecurityGroups": {
       "member": {
+        "locationName": "DBSecurityGroup",
         "shape": "DBSecurityGroup"
       },
       "name": "DBSecurityGroups",
@@ -1169,6 +1174,7 @@
     },
     "DBSnapshots": {
       "member": {
+        "locationName": "DBSnapshot",
         "shape": "DBSnapshot"
       },
       "name": "DBSnapshots",
@@ -1176,6 +1182,7 @@
     },
     "Datapoints": {
       "member": {
+        "locationName": "member",
         "shape": "Member"
       },
       "name": "Datapoints",
@@ -1340,6 +1347,7 @@
     },
     "DescribeDBLogFiles": {
       "member": {
+        "locationName": "DescribeDBLogFilesDetails",
         "shape": "DescribeDBLogFilesDetails"
       },
       "name": "DescribeDBLogFiles",
@@ -1760,6 +1768,7 @@
     },
     "EC2SecurityGroups": {
       "member": {
+        "locationName": "EC2SecurityGroup",
         "shape": "EC2SecurityGroup"
       },
       "name": "EC2SecurityGroups",
@@ -1844,6 +1853,7 @@
     },
     "EventCategoriesMapList": {
       "member": {
+        "locationName": "EventCategoriesMap",
         "shape": "EventCategoriesMap"
       },
       "name": "EventCategoriesMapList",
@@ -1884,6 +1894,7 @@
     },
     "EventSubscriptionsList": {
       "member": {
+        "locationName": "EventSubscription",
         "shape": "EventSubscription"
       },
       "name": "EventSubscriptionsList",
@@ -1891,6 +1902,7 @@
     },
     "Events": {
       "member": {
+        "locationName": "Event",
         "shape": "Event"
       },
       "name": "Events",
@@ -1910,6 +1922,7 @@
     },
     "IPRanges": {
       "member": {
+        "locationName": "IPRange",
         "shape": "IPRange"
       },
       "name": "IPRanges",
@@ -2024,7 +2037,7 @@
         },
         "Parameters": {
           "locationName": "Parameters",
-          "shape": "RequestParametersStruct"
+          "shape": "RequestParameters"
         }
       },
       "name": "ModifyDBParameterGroupRequest",
@@ -2159,6 +2172,7 @@
     },
     "OptionGroupMemberships": {
       "member": {
+        "locationName": "OptionGroupMembership",
         "shape": "OptionGroupMembership"
       },
       "name": "OptionGroupMemberships",
@@ -2196,6 +2210,7 @@
     },
     "OrderableDBInstanceOptions": {
       "member": {
+        "locationName": "OrderableDBInstanceOption",
         "shape": "OrderableDBInstanceOption"
       },
       "name": "OrderableDBInstanceOptions",
@@ -2239,6 +2254,7 @@
     },
     "Parameters": {
       "member": {
+        "locationName": "Parameter",
         "shape": "Parameter"
       },
       "name": "Parameters",
@@ -2288,6 +2304,7 @@
     },
     "ReadReplicaDBInstanceIdentifiers": {
       "member": {
+        "locationName": "ReadReplicaDBInstanceIdentifier",
         "shape": "ReadReplicaDBInstanceIdentifier"
       },
       "name": "ReadReplicaDBInstanceIdentifiers",
@@ -2397,14 +2414,15 @@
       "name": "RequestNiftyEmailAddresses",
       "type": "list"
     },
-    "RequestParameter": {
+    "RequestParameters": {
       "member": {
-        "shape": "RequestParameterStruct"
+        "locationName": "member",
+        "shape": "RequestParametersStruct"
       },
-      "name": "RequestParameter",
+      "name": "RequestParameters",
       "type": "list"
     },
-    "RequestParameterStruct": {
+    "RequestParametersStruct": {
       "members": {
         "ApplyMethod": {
           "locationName": "ApplyMethod",
@@ -2417,16 +2435,6 @@
         "ParameterValue": {
           "locationName": "ParameterValue",
           "shape": "String"
-        }
-      },
-      "name": "RequestParameterStruct",
-      "type": "structure"
-    },
-    "RequestParametersStruct": {
-      "members": {
-        "RequestParameter": {
-          "locationName": "Parameter",
-          "shape": "RequestParameter"
         }
       },
       "name": "RequestParametersStruct",
@@ -2448,7 +2456,7 @@
         },
         "Parameters": {
           "locationName": "Parameters",
-          "shape": "RequestParametersStruct"
+          "shape": "RequestParameters"
         },
         "ResetAllParameters": {
           "locationName": "ResetAllParameters",
@@ -2701,6 +2709,7 @@
     },
     "StatusInfos": {
       "member": {
+        "locationName": "DBInstanceStatusInfo",
         "shape": "DBInstanceStatusInfo"
       },
       "name": "StatusInfos",
@@ -2721,6 +2730,7 @@
     },
     "VpcSecurityGroups": {
       "member": {
+        "locationName": "VpcSecurityGroup",
         "shape": "VpcSecurityGroup"
       },
       "name": "VpcSecurityGroups",


### PR DESCRIPTION
## Summary

* fix #11 
* add location names for other SDKs

## Tests

* [x] `PYTHONPATH=. python scripts/nifcloud-debugcli rdb modify-db-parameter-group --db-parameter-group-name ${your_group_name} --parameters "ApplyMethod=immediate,ParameterName=autocommit,ParameterValue=0" --debug`