### PR TITLE
fix botocore and awscli versions in setup.*

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ universal = 1
 
 [metadata]
 requires-dist =
-  botocore>=1.9.11
-  awscli>=1.14.63
+  botocore>=1.10.70
+  awscli>=1.15.71
 license_file = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
                                'data/topics/*',
                                'data/*/*/*.json']},
     include_package_data=True,
-    install_requires=['botocore==1.9.16', 'awscli==1.14.63'],
+    install_requires=['botocore==1.10.70', 'awscli==1.15.71'],
     license='Apache License 2.0',
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
## 概要

* setup.cfg, setup.py に書いてある botocore, awscli のバージョンを Pipfile.lock に書いてあるバージョンに合わせました
* #17 の修正漏れ

## テスト手順

* [x] `docker run -it --rm -v $(pwd):/work -w /work python:3.6.3 bash`
    * なぜか /usr/local/app にマウントするのではダメだった
* [x] `python setup.py install`
    * 上記コンテナ内で実行、エラーが出ないこと
* [x] `nifcloud-debugcli`
    * 上記コンテナ内で実行、エラーが出ないこと