### PR TITLE
Add markdown support for pypi long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     version=find_version('nifcloud', '__init__.py'),
     description='Data-driven NIFCLOUD SDK for Python (Developer Preview)',
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     author='FUJITSU CLOUD TECHNOLOGIES',
     url='https://github.com/nifcloud/nifcloud-sdk-python',
     scripts=['scripts/nifcloud-debugcli'],


### PR DESCRIPTION
## Summary

- Support markdown format for the pypi long description.

## Tests

- [x] Confirm the version of setuptools is `>= v38.6.0`
- [x] Confirm that the contents of `README.md` is rendered correctly in pypi test environment