### PR TITLE
Fix service-2.json for computing

### DIFF
--- a/nifcloud/data/computing/3.0/service-2.json
+++ b/nifcloud/data/computing/3.0/service-2.json
@@ -10227,11 +10227,11 @@
       "members": {
         "InstanceSnapshotId": {
           "locationName": "InstanceSnapshotId",
-          "shape": "RequestInstanceSnapshotId"
+          "shape": "String"
         },
         "SnapshotName": {
           "locationName": "SnapshotName",
-          "shape": "RequestSnapshotName"
+          "shape": "String"
         }
       },
       "name": "NiftyDeleteInstanceSnapshotRequest",


### PR DESCRIPTION
## Summary

- Fix bugs for NiftyDeleteInstanceSnapshot

## Checks

- [x] `docker-compose build`
- [x] `vim .env`
    ```
    $ more .env
    AWS_ACCESS_KEY_ID=
    AWS_SECRET_ACCESS_KEY=
    AWS_DEFAULT_REGION=
    ```

- [x] The following command must complete normaly

    ```
    docker-compose run --rm app python scripts/nifcloud-debugcli computing nifty-delete-instance-snapshot --snapshot-name {SNAPSHOT_NAME}
    ```

- [x] The following command must complete normaly

    ```
    docker-compose run --rm app python scripts/nifcloud-debugcli computing nifty-delete-instance-snapshot --instance-snapshot-id {SNAPSHOT_ID}
    ```