### PR TITLE
Fix CLI command name

### DIFF
--- a/scripts/nifcloud-debugcli
+++ b/scripts/nifcloud-debugcli
@@ -16,7 +16,7 @@ from nifcloud import __version__ as nifcloud_version
 from nifcloud import session
 
 AWS_CLI_COMMAND = 'aws'
-NIFCLOUD_CLI_COMMAND = 'nifcloud-debug-cli'
+NIFCLOUD_CLI_COMMAND = 'nifcloud-debugcli'
 AWS_SERVICE_NAME = 'AWS'
 NIFCLOUD_SERVICE_NAME = 'NIFCLOUD'
 


### PR DESCRIPTION
## Summary

* fix CLI command name (`s/nifcloud-debug-cli/nifcloud-debugcli/`)

## Tests

* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli`
    * confirm that the CLI command name is displayed as `nifcloud-debugcli` instead of `nifcloud-debug-cli`