### PR TITLE
Fix help text on CLI parameter error

### DIFF
--- a/scripts/nifcloud-debugcli
+++ b/scripts/nifcloud-debugcli
@@ -24,6 +24,7 @@ argparser.USAGE = argparser.USAGE.replace(
     AWS_CLI_COMMAND,
     NIFCLOUD_CLI_COMMAND
 )
+clidriver.USAGE = argparser.USAGE
 
 root_dir = os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__)


### PR DESCRIPTION
## Summary

* Fix help text on CLI parameter error (`s/aws/nifcloud-debugcli/g`)

## Tests

* [x] `nifcloud-debugcli  computing describe-instances --hoge`
    * the command name is not `aws` but `nifcloud-debugcli`