### PR TITLE
fix upload-ssl-certificate bug

### DIFF
--- a/nifcloud/data/computing/3.0/service-2.json
+++ b/nifcloud/data/computing/3.0/service-2.json
@@ -18913,12 +18913,12 @@
     },
     "UploadSslCertificateRequest": {
       "members": {
-        "Ca": {
-          "locationName": "Ca",
-          "shape": "String"
-        },
         "Certificate": {
           "locationName": "Certificate",
+          "shape": "String"
+        },
+        "CertificateAuthority": {
+          "locationName": "Ca",
           "shape": "String"
         },
         "Key": {


### PR DESCRIPTION
## Summary

* #13 

## Tests

- [x] `docker-compose run --rm app bash -c "PYTHONPATH=. python scripts/nifcloud-debugcli computing upload-ssl-certificate help"` で `--certificate-authority` というパラメータが存在していること。
- [x] 下記手順で適当な証明書を作成。

```sh
openssl genrsa 2048 > ca.key
openssl req -x509 -new -nodes -key ca.key -subj "/CN=rootca" -days 10000 -out ca.crt
openssl genrsa 2048 > server.key
openssl req -new -key server.key -subj "/CN=servername" > server.csr
openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 10000 -out server.crt
```

- [x] `docker-compose run --rm app bash -c "PYTHONPATH=. python scripts/nifcloud-debugcli computing upload-ssl-certificate --key=file://./server.key --certificate=file://./server.crt --certificate-authority=file://./ca.crt"` で証明書をアップロードできそうなこと。