### PR TITLE
fix modify / reset db-parameter-group bug

### DIFF
--- a/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
+++ b/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
@@ -2206,7 +2206,7 @@
         },
         "Parameters": {
           "locationName": "Parameters",
-          "shape": "RequestParametersStruct"
+          "shape": "RequestParameters"
         }
       },
       "name": "ModifyDBParameterGroupRequest",
@@ -2590,14 +2590,15 @@
       "name": "RequestNiftyEmailAddresses",
       "type": "list"
     },
-    "RequestParameter": {
+    "RequestParameters": {
       "member": {
-        "shape": "RequestParameterStruct"
+        "locationName": "member",
+        "shape": "RequestParametersStruct"
       },
-      "name": "RequestParameter",
+      "name": "RequestParameters",
       "type": "list"
     },
-    "RequestParameterStruct": {
+    "RequestParametersStruct": {
       "members": {
         "ApplyMethod": {
           "locationName": "ApplyMethod",
@@ -2610,16 +2611,6 @@
         "ParameterValue": {
           "locationName": "ParameterValue",
           "shape": "String"
-        }
-      },
-      "name": "RequestParameterStruct",
-      "type": "structure"
-    },
-    "RequestParametersStruct": {
-      "members": {
-        "RequestParameter": {
-          "locationName": "Parameter",
-          "shape": "RequestParameter"
         }
       },
       "name": "RequestParametersStruct",
@@ -2641,7 +2632,7 @@
         },
         "Parameters": {
           "locationName": "Parameters",
-          "shape": "RequestParametersStruct"
+          "shape": "RequestParameters"
         },
         "ResetAllParameters": {
           "locationName": "ResetAllParameters",


### PR DESCRIPTION
## Summary

* fix modify / reset db-parameter-group bugs generate by #31 

## Tests

* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli rdb create-db-parameter-group --db-parameter-group-name test --db-parameter-group-family mysql5.5 --description hello`
* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli rdb modify-db-parameter-group --db-parameter-group-name test --parameters 'ApplyMethod=immediate,ParameterName=slow_query_log,ParameterValue=1'`
* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli rdb reset-db-parameter-group --db-parameter-group-name test --parameters 'ApplyMethod=immediate,ParameterName=slow_query_log'`
* [x] `docker-compose run --rm app python scripts/nifcloud-debugcli rdb delete-db-parameter-group --db-parameter-group-name test`