### PR TITLE
Fix lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
       pipenv install --skip-lock configparser==3.5.0 futures==3.2.0 urllib3==1.22
     fi
 script:
-  - pipenv run isort --check-only --diff --quiet
+  - pipenv run isort . --check-only --diff --quiet
   - pipenv run lint

--- a/nifcloud/serialize.py
+++ b/nifcloud/serialize.py
@@ -14,8 +14,11 @@ class ComputingSerializer(serialize.EC2Serializer):
             serialized["body"] = self._fix_describe_load_balancers_params(
                 parameters, operation_model.metadata['apiVersion']
             )
-        # Fix request parameters of RunInstances, StartInstances, RebootInstances for NIFCLOUD
-        if operation_model.name in ['RunInstances', 'StartInstances', 'RebootInstances']:
+        # Fix user data param of below actions for NIFCLOUD
+        user_data_fix_target = ['RunInstances',
+                                'StartInstances',
+                                'RebootInstances']
+        if operation_model.name in user_data_fix_target:
             serialized = self._fix_user_data_param(
                 serialized
             )


### PR DESCRIPTION
# Summary

- Fixed below lint errors

```
./nifcloud/serialize.py:17:80: E501 line too long (94 > 79 characters)
./nifcloud/serialize.py:18:80: E501 line too long (89 > 79 characters)
```

- Fixed isort option

```
Nothing to do: no files or paths have have been passed in!

Try one of the following:

    `isort .` - sort all Python files, starting from the current directory, recursively.
    `isort . --interactive` - Do the same, but ask before making any changes.
    `isort . --check --diff` - Check to see if imports are correctly sorted within this project.
    `isort --help` - In-depth information about isort's available command-line options.

Visit https://timothycrosley.github.io/isort/ for complete information about how to use isort.```