### PR TITLE
Add rdb and nas protocol for date

### DIFF
--- a/nifcloud/data/nas/N2016-02-24/service-2.json
+++ b/nifcloud/data/nas/N2016-02-24/service-2.json
@@ -2,7 +2,7 @@
   "metadata": {
     "apiVersion": "N2016-02-24",
     "endpointPrefix": "nas",
-    "protocol": "query",
+    "protocol": "nas",
     "serviceAbbreviation": "nas",
     "serviceFullName": "NIFCLOUD NAS",
     "serviceId": "nas",

--- a/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
+++ b/nifcloud/data/rdb/2013-05-15N2013-12-16/service-2.json
@@ -2,7 +2,7 @@
   "metadata": {
     "apiVersion": "2013-05-15N2013-12-16",
     "endpointPrefix": "rdb",
-    "protocol": "query",
+    "protocol": "rdb",
     "serviceAbbreviation": "rdb",
     "serviceFullName": "NIFCLOUD RDB",
     "serviceId": "rdb",

--- a/nifcloud/parsers.py
+++ b/nifcloud/parsers.py
@@ -23,5 +23,7 @@ class ComputingQueryParser(parsers.QueryParser):
 
 parsers.PROTOCOL_PARSERS.update({
     'computing': ComputingQueryParser,
-    'script': parsers.QueryParser
+    'script': parsers.QueryParser,
+    'rdb': parsers.QueryParser,
+    'nas': parsers.QueryParser
 })

--- a/nifcloud/serialize.py
+++ b/nifcloud/serialize.py
@@ -1,4 +1,5 @@
 from botocore import serialize
+from datetime import datetime as dt
 
 
 # handles both Hoge.1 / Hoges.member.1 parameter according to locationName
@@ -69,7 +70,72 @@ class ScriptSerializer(serialize.QuerySerializer):
         return serialized
 
 
+class RdbSerializer(serialize.QuerySerializer):
+
+    def serialize_to_request(self, parameters, operation_model):
+        serialized = super(RdbSerializer, self).serialize_to_request(
+            parameters, operation_model
+        )
+        serialized['url_path'] = operation_model.http.get('requestUri', '/')
+        # Fix request parameters of NiftyGetMetricStatistics for NIFCLOUD RDB
+        if operation_model.name == 'NiftyGetMetricStatistics':
+            serialized["body"] = _fix_get_metrics_statistics_params(
+                self,
+                parameters,
+                operation_model.metadata['apiVersion'],
+                operation_model.name
+            )
+        return serialized
+
+
+class NasSerializer(serialize.QuerySerializer):
+
+    def serialize_to_request(self, parameters, operation_model):
+        serialized = super(NasSerializer, self).serialize_to_request(
+            parameters, operation_model
+        )
+        serialized['url_path'] = operation_model.http.get('requestUri', '/')
+        # Fix request parameters of GetMetricStatistics for NIFCLOUD NAS
+        if operation_model.name == 'GetMetricStatistics':
+            serialized["body"] = _fix_get_metrics_statistics_params(
+                self,
+                parameters,
+                operation_model.metadata['apiVersion'],
+                operation_model.name
+            )
+        return serialized
+
+
+def _fix_get_metrics_statistics_params(
+         self, params, api_version, operation_model_name):
+    prefix = 'Dimensions'
+    body = {
+        "Action": operation_model_name,
+        "Version": api_version
+    }
+    if not params.get(prefix) and not params.get('MetricName'):
+        return body
+    for i, param in enumerate(params[prefix], 1):
+        body['%s.member.%d.Name' % (prefix, i)] = param['Name']
+        body['%s.member.%d.Value' % (prefix, i)] = param['Value']
+    body['MetricName'] = params['MetricName']
+    # Convert from %Y-%m-%dT%H:%M:%SZ to %Y-%m-%d %H:%M
+    if params.get('StartTime'):
+        if type(params.get('StartTime')) is str:
+            params['StartTime'] = dt.strptime(params['StartTime'],
+                                              '%Y-%m-%dT%H:%M:%SZ')
+        body['StartTime'] = params['StartTime'].strftime('%Y-%m-%d %H:%M')
+    if params.get('EndTime'):
+        if type(params.get('EndTime')) is str:
+            params['EndTime'] = dt.strptime(params['EndTime'],
+                                            '%Y-%m-%dT%H:%M:%SZ')
+        body['EndTime'] = params['EndTime'].strftime('%Y-%m-%d %H:%M')
+    return body
+
+
 serialize.SERIALIZERS.update({
     'computing': ComputingSerializer,
-    'script': ScriptSerializer
+    'script': ScriptSerializer,
+    'rdb': RdbSerializer,
+    'nas': NasSerializer
 })


### PR DESCRIPTION
## Summary

fixed #20 

## Tests

- [x] Please test samples

```
from nifcloud import session
import datetime

client = session.get_session().create_client(
    "rdb",
    region_name="jp-east-1",
    aws_access_key_id="XXXX",
    aws_secret_access_key="YYYY"
)

td_3m = datetime.timedelta(minutes=3)
td_9h = datetime.timedelta(hours=9)
end = datetime.datetime.now() - td_9h
start = end - td_3m

print(client.nifty_get_metric_statistics(
    Dimensions=[
        {
            'Name': 'DBInstanceIdentifier',
            'Value': 'sdktestdb001'
        },
    ],
    MetricName='CPUUtilization',
    StartTime=start,
    EndTime=end
))
``` 

```
from nifcloud import session
import datetime

client = session.get_session().create_client(
    "nas",
    region_name="jp-east-1",
    aws_access_key_id="XXXX",
    aws_secret_access_key="YYYY"
)

td_3m = datetime.timedelta(minutes=3)
end = datetime.datetime.now()
start = end - td_3m

print(client.get_metric_statistics(
    Dimensions=[
        {
            'Name': 'NASInstanceIdentifier',
            'Value': 'sdktestnas001'
        },
    ],
    MetricName='FreeStorageSpace',
    StartTime=start,
    EndTime=end
))
```