### PR TITLE
Replace 'AWS_' with 'NIFCLOUD_'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ from nifcloud import session
 client = session.get_session().create_client(
     "computing",
     region_name="jp-east-1",
-    aws_access_key_id="<Your NIFCLOUD Access Key ID>",
-    aws_secret_access_key="<Your NIFCLOUD Secret Access Key>"
+    nifcloud_access_key_id="<Your NIFCLOUD Access Key ID>",
+    nifcloud_secret_access_key="<Your NIFCLOUD Secret Access Key>"
 )
 
 print(client.describe_instances())
@@ -56,9 +56,9 @@ print(client.describe_instances())
 ```
 
 ```
-$ export AWS_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
-$ export AWS_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
-$ export AWS_DEFAULT_REGION=jp-east-1
+$ export NIFCLOUD_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
+$ export NIFCLOUD_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
+$ export NIFCLOUD_DEFAULT_REGION=jp-east-1
 $ python test.py
 ```
 
@@ -70,9 +70,9 @@ See [documentation](https://nifcloud-sdk-python.readthedocs.io/en/latest/) for d
 
 ```
 ## Set credentials and default region
-$ export AWS_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
-$ export AWS_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
-$ export AWS_DEFAULT_REGION=jp-east-1
+$ export NIFCLOUD_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
+$ export NIFCLOUD_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
+$ export NIFCLOUD_DEFAULT_REGION=jp-east-1
 
 ## Show available services
 $ nifcloud-debugcli help

--- a/nifcloud/__init__.py
+++ b/nifcloud/__init__.py
@@ -1,4 +1,4 @@
-from . import (auth, configprovider, loaders, parsers, serialize,  # noqa: F401
-               session)
+from . import (auth, configprovider, credentials, loaders,  # noqa: F401
+               parsers, serialize, session)
 
 __version__ = '0.13.0'

--- a/nifcloud/configprovider.py
+++ b/nifcloud/configprovider.py
@@ -1,10 +1,11 @@
 from botocore import configprovider
 
 configprovider.BOTOCORE_DEFAUT_SESSION_VARIABLES.update({
-    'config_file': (
-        None, 'AWS_CONFIG_FILE', '~/.nifcloud/config', None
-    ),
+    'profile': (None, ['NIFCLOUD_DEFAULT_PROFILE', 'NIFCLOUD_PROFILE'], None, None),
+    'region': ('region', 'NIFCLOUD_DEFAULT_REGION', None, None),
+    'data_path': ('data_path', 'NIFCLOUD_DATA_PATH', None, None),
+    'config_file': (None, 'NIFCLOUD_CONFIG_FILE', '~/.nifcloud/config', None),
     'credentials_file': (
-        None, 'AWS_SHARED_CREDENTIALS_FILE', '~/.nifcloud/credentials', None
+        None, 'NIFCLOUD_SHARED_CREDENTIALS_FILE', '~/.nifcloud/credentials', None
     )
 })

--- a/nifcloud/credentials.py
+++ b/nifcloud/credentials.py
@@ -1,0 +1,4 @@
+from botocore.credentials import EnvProvider
+
+EnvProvider.ACCESS_KEY = "NIFCLOUD_ACCESS_KEY_ID"
+EnvProvider.SECRET_KEY = "NIFCLOUD_SECRET_ACCESS_KEY"

--- a/nifcloud/session.py
+++ b/nifcloud/session.py
@@ -15,5 +15,14 @@ class Session(session.Session):
         self.user_agent_version = nifcloud.__version__
         self.user_agent_extra = 'botocore/%s' % botocore_version
 
+    def create_client(self, service_name, region_name=None, api_version=None,
+                      use_ssl=True, verify=None, endpoint_url=None,
+                      nifcloud_access_key_id=None, nifcloud_secret_access_key=None,
+                      nifcloud_session_token=None, config=None):
+        return super(Session, self).create_client(
+            service_name, region_name=region_name, api_version=api_version, use_ssl=use_ssl,
+            verify=verify, endpoint_url=endpoint_url, aws_access_key_id=nifcloud_access_key_id,
+            aws_secret_access_key=nifcloud_secret_access_key, aws_session_token=nifcloud_session_token, config=config)
+
 
 session.Session = Session

--- a/scripts/nifcloud-debugcli
+++ b/scripts/nifcloud-debugcli
@@ -178,12 +178,12 @@ clidriver.CLIDriver = CLIDriver
 
 # Delete awscli data path from botocore's search path
 _cli_data_path = []
-if 'AWS_DATA_PATH' in os.environ:
-    for path in os.environ['AWS_DATA_PATH'].split(os.pathsep)[:-1]:
+if 'NIFCLOUD_DATA_PATH' in os.environ:
+    for path in os.environ['NIFCLOUD_DATA_PATH'].split(os.pathsep)[:-1]:
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
         _cli_data_path.append(path)
-os.environ['AWS_DATA_PATH'] = os.pathsep.join(_cli_data_path)
+os.environ['NIFCLOUD_DATA_PATH'] = os.pathsep.join(_cli_data_path)
 
 
 def awscli_initialize(event_handlers):


### PR DESCRIPTION
# Summary

- `AWS_` (`aws_`) -> `NIFCLOUD_` (`nifcloud_`)

# Tests

- [x] using SDK with hard-coded credentials 

```python
from nifcloud import session

client = session.get_session().create_client(
    "computing",
    region_name="jp-east-1",
    nifcloud_access_key_id="<Your NIFCLOUD Access Key ID>",
    nifcloud_secret_access_key="<Your NIFCLOUD Secret Access Key>"
)

print(client.describe_instances())
```

- [x] read credential values from environment variable.

```python
from nifcloud import session

client = session.get_session().create_client(
    "computing",
)

print(client.describe_instances())
```

```sh
$ export NIFCLOUD_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
$ export NIFCLOUD_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
$ export NIFCLOUD_DEFAULT_REGION=jp-east-1
$ python test.py
```

- [x] using CLI with environment variable

```sh
$ export NIFCLOUD_ACCESS_KEY_ID=<Your NIFCLOUD Access Key ID>
$ export NIFCLOUD_SECRET_ACCESS_KEY=<Your NIFCLOUD Secret Access Key>
$ export NIFCLOUD_DEFAULT_REGION=jp-east-1

$ nifcloud-debugcli computing describe-instances
```

- [x] using CLI with credential file

```sh
$ cat ~/.nifcloud/credentials
$ cat ~/.nifcloud/config
$ export NIFCLOUD_DEFAULT_PROFILE=<Your profile name>

# cleanup environment variables
$ export NIFCLOUD_ACCESS_KEY_ID=
$ export NIFCLOUD_SECRET_ACCESS_KEY=
$ export NIFCLOUD_DEFAULT_REGION=

$ nifcloud-debugcli computing describe-instances
```