### PR TITLE
Fix to stop the NASInstanceAvailable waiter when target instance state is failed

### DIFF
--- a/nifcloud/data/nas/N2016-02-24/waiters-2.json
+++ b/nifcloud/data/nas/N2016-02-24/waiters-2.json
@@ -29,6 +29,12 @@
           "expected": "available",
           "state": "success",
           "argument": "NASInstances[].NASInstanceStatus"
+        },
+        {
+          "matcher": "pathAll",
+          "expected": "failed",
+          "state": "failure",
+          "argument": "NASInstances[].NASInstanceStatus"
         }
       ]
     },


### PR DESCRIPTION
# Summary

- Fix to stop the NASInstanceAvailable waiter when target NAS instance state is failed.

# Tests

- [x] LGTM