### PR TITLE
Fix to override the botocore.docs.ServiceDocumenter

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,10 +16,10 @@
 import os
 
 from nifcloud import __version__
-from nifcloud.docs import generate_docs
+from nifcloud.docs import docs
 from nifcloud.session import get_session
 
-generate_docs(os.path.dirname(os.path.abspath(__file__)), get_session())
+docs.generate_docs(os.path.dirname(os.path.abspath(__file__)), get_session())
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/nifcloud/docs/__init__.py
+++ b/nifcloud/docs/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from botocore.docs import generate_docs  # noqa: F401
+from botocore import docs
 from botocore.docs import client, service
 
 NIFCLOUD_DOC_BASE = 'https://pfs.nifcloud.com/api'
@@ -30,4 +30,25 @@ class ClientDocumenter(client.ClientDocumenter):
         method_intro.push_write(replaced_text)
 
 
+class ServiceDocumenter(service.ServiceDocumenter):
+
+    def __init__(self, service_name, session):
+        self._session = session
+        self._service_name = service_name
+
+        self._client = self._session.create_client(
+            service_name, region_name='jp-east-1', nifcloud_access_key_id='foo',
+            nifcloud_secret_access_key='bar')
+        self._event_emitter = self._client.meta.events
+
+        self.sections = [
+            'title',
+            'table-of-contents',
+            'client-api',
+            'paginator-api',
+            'waiter-api'
+        ]
+
+
+docs.ServiceDocumenter = ServiceDocumenter
 service.ClientDocumenter = ClientDocumenter

--- a/nifcloud/docs/__init__.py
+++ b/nifcloud/docs/__init__.py
@@ -45,6 +45,7 @@ class ServiceDocumenter(service.ServiceDocumenter):
             'title',
             'table-of-contents',
             'client-api',
+            'client-exceptions',
             'paginator-api',
             'waiter-api'
         ]


### PR DESCRIPTION
# Summary

- Fix document generator because PR #73 includes the bugs.

# Tests

- [x] `cd docs && PYTHONPATH=../ make html` succeeded.