### PR TITLE
Feature/update python and pipenv version

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pipenv
-        run: pip install pipenv==2018.11.26
+        run: pip install pipenv==2023.5.19
 
       - name: Install dependencies
         run: pipenv install --skip-lock -d

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.9]
+        python-version: [2.7, 3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.11]
+        python-version: [3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pipenv
-        run: pip install pipenv==2021.05.29
+        run: pip install pipenv==2023.5.19
 
       - name: Install dependencies
         run: pipenv install --skip-lock -d
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pipenv
-        run: pip install pipenv==2021.05.29
+        run: pip install pipenv==2023.5.19
 
       - name: Install dependencies
         run: pipenv install --skip-lock -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3
+FROM python:3.11.3
 WORKDIR /usr/local/app
 RUN apt-get update && apt-get install -y groff-base
 ADD Pipfile /usr/local/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.11.3
 WORKDIR /usr/local/app
 RUN apt-get update && apt-get install -y groff-base
 ADD Pipfile /usr/local/app
-RUN pip install pipenv==2018.11.26 && pipenv install --skip-lock -d
+RUN pip install pipenv==2023.5.19 && pipenv install --skip-lock -d
 ENTRYPOINT ["pipenv", "run"]

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,9 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ),
 )


### PR DESCRIPTION
# Summary

- Update Python to 3.11
- Update Pipenv
- Delete Python 2.7 tests from CI because latest pipenv does not support it.