### PR TITLE
Bump sphinx version to 6.2.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ isort = "*"
 "flake8" = "*"
 pytest = "*"
 requests = "*"
-sphinx = "==1.8.1"
+sphinx = "==6.2.1"
 sphinx-rtd-theme = "*"
 
 [scripts]


### PR DESCRIPTION
# Summary

- Bump sphynx version to 6.2.1

# Tests

- [x] `docker run -it --rm -v $(pwd):/work -w /work python:3.11 bash`
- [x] `pip install pipenv`
- [x] `pipenv install -d --skip-lock`
- [x] `pipenv shell`
- [x] `export PYTHONPATH=$(pwd)`
- [x] `cd docs`
- [x] `make html`
- [x] `exit` (exit from container)
- [x] `cd docs/build/html && python -m http.server`
- [x] Check the generated documents via browser.