### PR TITLE
Downgrade Sphinx to 5.3.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ isort = "*"
 "flake8" = "*"
 pytest = "*"
 requests = "*"
-sphinx = "==6.2.1"
+sphinx = "==5.3.0"
 sphinx-rtd-theme = "*"
 
 [scripts]


### PR DESCRIPTION
# Summary

Downgrade Sphinx version to 5.3.0 because 6.x does not support Python 3.7.

# Tests

- [x] `docker run -it --rm -v $(pwd):/work -w /work python:3.7 bash`
- [x] `pip install pipenv`
- [x] `pipenv install -d` runs without errors.