### PR TITLE
Add config file for read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==5.3.0
+sphinx-rtd-theme


### PR DESCRIPTION
# Summary

- Read the Docs requires the configuration file to automatically build the document generated by sphinx.
    - https://docs.readthedocs.io/en/stable/config-file/v2.html

# Tests

- [x] the latest doc (https://nifcloud-sdk-python.readthedocs.io/en/latest/index.html) is good.